### PR TITLE
Added documentation file for React components

### DIFF
--- a/candis/app/client/app/component/widget/PipelineEditor.jsx
+++ b/candis/app/client/app/component/widget/PipelineEditor.jsx
@@ -8,6 +8,10 @@ import Media      from './Media'
 import Pipeline   from '../../constant/Pipeline'
 import { stage }  from '../../action/DocumentProcessorAction'
 
+/**
+ * Renders active pipeline stages in the form of an unordered list.
+ */
+
 class PipelineEditor extends React.Component
 {
 	render ( )

--- a/docs/Client/componentsDocs.json
+++ b/docs/Client/componentsDocs.json
@@ -1,0 +1,744 @@
+{
+  "candis\\app\\client\\app\\component\\App.jsx": {
+    "description": "",
+    "displayName": "App",
+    "methods": []
+  },
+  "candis\\app\\client\\app\\component\\AppBar.jsx": {
+    "description": "",
+    "displayName": "AppBar",
+    "methods": [],
+    "props": {
+      "ID": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "shortid.generate()",
+          "computed": true
+        }
+      },
+      "classNames": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "{ }",
+          "computed": false
+        }
+      },
+      "fluid": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "image": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      },
+      "title": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\PrivateRoute.jsx": {
+    "description": "",
+    "displayName": "PrivateRoute",
+    "methods": [],
+    "props": {
+      "user": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\form\\SignInForm.jsx": {
+    "description": "",
+    "displayName": "SignInForm",
+    "methods": [
+      {
+        "name": "onChange",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "event",
+            "type": null
+          }
+        ],
+        "returns": null
+      },
+      {
+        "name": "onSubmit",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "event",
+            "type": null
+          }
+        ],
+        "returns": null
+      }
+    ],
+    "props": {
+      "onChange": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "(data) => { }",
+          "computed": false
+        }
+      },
+      "onSubmit": {
+        "type": {
+          "name": "func"
+        },
+        "required": true,
+        "description": ""
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\DataEditor.jsx": {
+    "description": "",
+    "displayName": "DataEditor",
+    "methods": []
+  },
+  "candis\\app\\client\\app\\component\\widget\\FileEditor.jsx": {
+    "description": "",
+    "displayName": "FileEditor",
+    "methods": [],
+    "props": {
+      "classNames": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "{ }",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\FileViewer.jsx": {
+    "description": "",
+    "displayName": "FileViewer",
+    "methods": [
+      {
+        "name": "onChange",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "value",
+            "type": null
+          }
+        ],
+        "returns": null
+      }
+    ],
+    "props": {
+      "classNames": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "{ }",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\GistViewer.jsx": {
+    "description": "",
+    "displayName": "GistViewer",
+    "methods": []
+  },
+  "candis\\app\\client\\app\\component\\widget\\Media.jsx": {
+    "description": "",
+    "displayName": "Media",
+    "methods": [],
+    "props": {
+      "icon": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      },
+      "title": {
+        "type": {
+          "name": "string"
+        },
+        "required": true,
+        "description": ""
+      },
+      "body": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\MenuBar.jsx": {
+    "description": "",
+    "displayName": "MenuBar",
+    "methods": [],
+    "props": {
+      "ID": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "shortid.generate()",
+          "computed": true
+        }
+      },
+      "classNames": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "{ }",
+          "computed": false
+        }
+      },
+      "menus": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "[ ]",
+          "computed": false
+        }
+      },
+      "fluid": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "onClick": {
+        "type": {
+          "name": "func"
+        },
+        "required": true,
+        "description": ""
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\Modal.jsx": {
+    "description": "",
+    "displayName": "Modal",
+    "methods": [],
+    "props": {
+      "ID": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "shortid.generate()",
+          "computed": true
+        }
+      },
+      "display": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "modal": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "{ }",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\PipelineEditor.jsx": {
+    "description": "Renders active pipeline stages in the form of an unordered list.",
+    "displayName": "PipelineEditor",
+    "methods": []
+  },
+  "candis\\app\\client\\app\\component\\widget\\SelectViewer.jsx": {
+    "description": "",
+    "displayName": "SelectViewer",
+    "methods": [
+      {
+        "name": "onChange",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "value",
+            "type": null
+          }
+        ],
+        "returns": null
+      }
+    ],
+    "props": {
+      "classNames": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "{ }",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\TabBar.jsx": {
+    "description": "",
+    "displayName": "TabBar",
+    "methods": [],
+    "props": {
+      "tabs": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "[ ]",
+          "computed": false
+        }
+      },
+      "menu": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "[ ]",
+          "computed": false
+        }
+      },
+      "onClick": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "() => { }",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\ToolBar.jsx": {
+    "description": "",
+    "displayName": "ToolBar",
+    "methods": [],
+    "props": {
+      "tools": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "[ ]",
+          "computed": false
+        }
+      },
+      "classNames": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "{ }",
+          "computed": false
+        }
+      },
+      "size": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "20",
+          "computed": false
+        }
+      },
+      "onClick": {
+        "type": {
+          "name": "func"
+        },
+        "required": true,
+        "description": ""
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\TypeAhead.jsx": {
+    "description": "",
+    "displayName": "TypeAhead",
+    "methods": [
+      {
+        "name": "onChange",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "event",
+            "type": null
+          }
+        ],
+        "returns": null
+      }
+    ],
+    "props": {
+      "placeholder": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "\"\"",
+          "computed": false
+        }
+      },
+      "data": {
+        "type": {
+          "name": "array"
+        },
+        "required": true,
+        "description": ""
+      },
+      "onSelect": {
+        "type": {
+          "name": "func"
+        },
+        "required": true,
+        "description": ""
+      },
+      "maximum": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      },
+      "keys": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": ""
+      },
+      "onMouseOver": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "() => { }",
+          "computed": false
+        }
+      },
+      "onMouseOut": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "() => { }",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\XEditable.jsx": {
+    "description": "",
+    "displayName": "XEditable",
+    "methods": [],
+    "props": {
+      "ID": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "shortid.generate()",
+          "computed": true
+        }
+      },
+      "title": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "\"\"",
+          "computed": false
+        }
+      },
+      "value": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "\"\"",
+          "computed": false
+        }
+      },
+      "empty": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "\"\"",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\document\\DocumentPanel.jsx": {
+    "description": "",
+    "displayName": "DocumentPanel",
+    "methods": [],
+    "props": {
+      "documents": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "[ ]",
+          "computed": false
+        }
+      },
+      "onActive": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "(dokument) => { }",
+          "computed": false
+        }
+      },
+      "active": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\document\\DocumentProcessor.jsx": {
+    "description": "",
+    "displayName": "DocumentProcessor",
+    "methods": [],
+    "props": {
+      "documents": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "[ ]",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\toolbox\\Compartment.jsx": {
+    "description": "",
+    "displayName": "Compartment",
+    "methods": []
+  },
+  "candis\\app\\client\\app\\component\\widget\\toolbox\\TipView.jsx": {
+    "description": "",
+    "displayName": "TipView",
+    "methods": [],
+    "props": {
+      "title": {
+        "type": {
+          "name": "string"
+        },
+        "required": true,
+        "description": ""
+      },
+      "content": {
+        "type": {
+          "name": "string"
+        },
+        "required": true,
+        "description": ""
+      }
+    }
+  },
+  "candis\\app\\client\\app\\component\\widget\\toolbox\\ToolBox.jsx": {
+    "description": "",
+    "displayName": "ToolBox",
+    "methods": [],
+    "props": {
+      "ID": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "shortid.generate()",
+          "computed": true
+        }
+      },
+      "title": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "\"\"",
+          "computed": false
+        }
+      },
+      "compartments": {
+        "type": {
+          "name": "array"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "[ ]",
+          "computed": false
+        }
+      }
+    }
+  },
+  "candis\\app\\client\\app\\page\\SignIn.jsx": {
+    "description": "",
+    "displayName": "SignIn",
+    "methods": [
+      {
+        "name": "onSubmit",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "data",
+            "type": null
+          }
+        ],
+        "returns": null
+      }
+    ],
+    "props": {
+      "user": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "null",
+          "computed": false
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "webpack": "webpack",
     "webpack.watch": "webpack --watch",
     "build": "yarn run webpack && yarn run sass",
-    "start": "concurrently --kill-others \"yarn run sass.watch\" \"yarn run webpack.watch\""
+    "start": "concurrently --kill-others \"yarn run sass.watch\" \"yarn run webpack.watch\"",
+    "react-docgen": "react-docgen candis/app/client/app --out docs/Client/componentsDocs.json --pretty"
   },
   "repository": {
     "type": "git",
@@ -53,6 +54,7 @@
     "prop-types": "^15.6.0",
     "react-data-grid": "^3.0.3",
     "react-data-grid-addons": "^3.0.3",
+    "react-docgen": "^2.20.1",
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
solves #31 
Currently, there are many components which make it difficult for a newcomer to parse through, having a documentation of such components will make it easy to know about the components. Hence, I have used an open-source library to generate documentation of components: [react-docgen](https://github.com/reactjs/react-docgen).

Now to generate/modify documentation run from root directory, `yarn run react-dogen`.

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None
