### PR TITLE
Travis setup successful

### DIFF
--- a/candis/ios/pipeline/pipeline.py
+++ b/candis/ios/pipeline/pipeline.py
@@ -26,7 +26,6 @@ from weka.plot.classifiers    import plot_classifier_errors, plot_learning_curve
 # imports - module imports
 from candis.config import CONFIG
 from candis.ios    import cdata
-from candis.ios    import pipeline
 from candis.ios    import json as JSON
 from candis.util   import assign_if_none, get_rand_uuid_str, get_b64_plot, buffer_to_b64
 

--- a/get-candis
+++ b/get-candis
@@ -151,15 +151,15 @@ def get_candis():
 
     Rscript = which('Rscript', raise_err = True)
     popen(Rscript, 'setup.R', dir = osp.join(appdir, 'R'))
-
+s
     python3 = which('python3', raise_err = True)
     pip3    = which('pip3',    raise_err = True)
     
     popen(pip3, 'install', '--upgrade', 'pip')
 
     popen(pip3, 'install', 'numpy') # Thanks, javabridge.
-    popen(pip3, 'install', '-r', 'requirements.txt',     dir = appdir)
-    popen(pip3, 'install', '-r', 'requirements-dev.txt', dir = appdir, raise_err = False)
+    popen(pip3, 'install', '--ignore-installed', '-r', 'requirements.txt',     dir = appdir)
+    # popen(pip3, 'install', '-r', 'requirements-dev.txt', dir = appdir, raise_err = False)
 
     # Force matplotlib backend for macOS
     if sys.platform == 'darwin':

--- a/get-candis
+++ b/get-candis
@@ -151,7 +151,7 @@ def get_candis():
 
     Rscript = which('Rscript', raise_err = True)
     popen(Rscript, 'setup.R', dir = osp.join(appdir, 'R'))
-s
+    
     python3 = which('python3', raise_err = True)
     pip3    = which('pip3',    raise_err = True)
     

--- a/package.py
+++ b/package.py
@@ -5,7 +5,10 @@ import io
 from   setuptools import find_packages
 
 # imports - third-party imports
-from   pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 # Python 2
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,9 @@ nbformat==4.4.0
 notebook==5.4.0
 numpy==1.14.0
 packaging==16.8
-pandas==0.22.0
+# pandas==0.22.0
+pandas; python_version >= '3.5'
+pandas<0.21; python_version == '3.4'
 pandocfilters==1.4.2
 parso==0.1.1
 pexpect==4.4.0


### PR DESCRIPTION
Changes made for travis build:

Added flag `--ignore-installed` for installing packages inside requirements.txt.
Reference: https://github.com/pypa/pip/issues/3384

Double requirement given: numpy==1.12.1 error – Issue and solution  https://github.com/pandas-dev/pandas/issues/20697 - Used conditional installing of pandas based on python version.
 pip.req (in package.py) import error – Added Exception handling to solve the recent pip10 issue. Refer: https://stackoverflow.com/questions/25192794/no-module-named-pip-req

Removed Import error in pipeline.py – There was a statement for import of its own, thus removed that finally made the build the successful, script key still needed to be added.
So basically pip10 is the main cause of failing travis build, every referred link has issues raised since last month.

