### PR TITLE
modify Makefile, setup pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ clean.force:
 	make clean
 	
 install:
-	$(PIPENV)  install
+	$(PIPENV)  install --skip-lock # skip-lock flag need to be removed after pipenv update.
 	$(YARN)    install
 
 	$(PYTHON) setup.py develop
@@ -70,7 +70,8 @@ upgrade:
 test:
 	make install
 
-	$(PYTEST)
+	$(PYTEST) --cov=candis.app.server.api candis/app/server/api/tests
+	$(YARN) test
 
 	make clean.py
 

--- a/candis/app/server/api/tests/test_data.py
+++ b/candis/app/server/api/tests/test_data.py
@@ -1,0 +1,5 @@
+from candis.app.server.api.data import get_filename_if_exists
+
+def test_get_filename_if_exists():
+    assert 2 == 2 
+    


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
 - changed Makefile according to pipenv error https://github.com/pypa/pipenv/issues/2078

Add pytest, pycov command in Makefile
Add directory for tests.

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
Once the update is released in pipenv, `--skip-lock` option can be removed.

Solves #46 