### PR TITLE
Exclude app/tests directory from jest test coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,8 @@ module.exports = {
 	"collectCoverageFrom" : [
 		"**/*.{js,jsx}",
 		"!**/node_modules/**",
-		"!**/vendor/**"
+		"!**/vendor/**",
+		"!**/app/tests/**",
 	],
 	"setupFiles" : [
 		"<rootDir>/candis/app/client/app/tests/setupTests.js"


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Its absurd to include tests folder in test coverage, so excluding it in the jest.config file.

