### PR TITLE
Remove unnecessary fixture

### DIFF
--- a/candis/app/client/app/tests/actions/PipelineAction.test.js
+++ b/candis/app/client/app/tests/actions/PipelineAction.test.js
@@ -5,26 +5,25 @@ import MockAdapter from 'axios-mock-adapter'
 
 import config from '../../config'
 import pipeline from '../../action/PipelineAction'
-import activePipe from '../fixtures/pipeline'
 import ActionType from '../../constant/ActionType'
-import dokuments from '../fixtures/documents'
+import dokuments, {newDoc} from '../fixtures/documents'
 
-
+const {name} = newDoc.output  // take out name of the pipelien to be deleted from an active dokument.
 const createMockStore = configureMockStore([thunk])
 const mock = new MockAdapter(axios)
 
  test('should setup pipeline.delete action object ', (done) => {
     const data = { data: 'true' }  // dummy data object for DELETE_SUCCESS action.
-    mock.onPost(config.routes.API.data.delete, { name: activePipe }).reply(200, data)
+    mock.onPost(config.routes.API.data.delete, { name }).reply(200, data)
     const store = createMockStore({})
-    store.dispatch(pipeline.delete(activePipe)).then(() => {
+    store.dispatch(pipeline.delete(name)).then(() => {
         
         const actions = store.getActions()
         expect(actions[0]).toEqual({
             type: ActionType.Asynchronous.DELETE_SUCCESS,
             payload: {
                 ...data,
-                name: activePipe
+                name
             }
         })
         expect(actions[1]).toEqual({
@@ -39,15 +38,15 @@ const mock = new MockAdapter(axios)
     const code = 404  // should be greater than or equal to 400
     const error = new Error(`Request failed with status code ${code}`)  
     
-    mock.onPost(config.routes.API.data.delete, { name: activePipe }).reply(code, error)
+    mock.onPost(config.routes.API.data.delete, { name }).reply(code, error)
     const store = createMockStore({})
-    store.dispatch(pipeline.delete(activePipe)).then(() => {
+    store.dispatch(pipeline.delete(name)).then(() => {
         
         const actions = store.getActions()
         expect(actions[0]).toEqual({
             type: ActionType.Asynchronous.DELETE_ERROR,
             payload: {
-                name: activePipe,
+                name,
                 error
             }
         })

--- a/candis/app/client/app/tests/fixtures/pipeline.js
+++ b/candis/app/client/app/tests/fixtures/pipeline.js
@@ -1,5 +1,0 @@
-export default {
-    name: 'testPipe.cpipe',
-    code: '1',
-    stages: []
-}


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - remove pipeline.js fixture, as docoments.js fixture can be utilized for the same (for a dummy pipeline).
  - related to #67 