### PR TITLE
Start Redis Server using honcho Manager class.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 
 BASEDIR      = $(realpath .)
 MODULE       = candis
+HONCHO_MANAGER = honcho_manager.py 
 
 SOURCEDIR    = $(realpath $(MODULE))
 DOCSDIR      = $(realpath docs)
@@ -102,9 +103,11 @@ console:
 
 start:
 ifeq ($(ENV), development)
-	$(HONCHO) start --procfile $(BASEDIR)/Procfile.dev
+	# $(HONCHO) start --procfile $(BASEDIR)/Procfile.dev
+	$(PYTHON) $(BASEDIR)/$(HONCHO_MANAGER) --env 'dev'
 else
-	$(HONCHO) start
+	# $(HONCHO) start
+	$(PYTHON) $(BASEDIR)/$(HONCHO_MANAGER) --env 'prod'
 endif
 
 release:

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: gunicorn candis.app:app
-redis: redis-server --port $REDIS_PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn candis.app:app
+redis: redis-server --port $REDIS_PORT

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
 web: python -m candis
 node: npm start
-redis: redis-server --port $REDIS_PORT

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: python -m candis
 node: npm start
+redis: redis-server --port $REDIS_PORT

--- a/get-candis
+++ b/get-candis
@@ -217,6 +217,9 @@ def setup_candis(args = None):
             popen('curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -')
             popen('echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list')
             popen('sudo apt-get update && sudo apt-get install yarn')
+
+            # Set environment variable.
+            popen('export', 'REDIS_PORT=6380')
             
             # Auto Agree License.
             popen('echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections')

--- a/get-candis
+++ b/get-candis
@@ -217,9 +217,6 @@ def setup_candis(args = None):
             popen('curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -')
             popen('echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list')
             popen('sudo apt-get update && sudo apt-get install yarn')
-
-            # Set environment variable.
-            popen('export', 'REDIS_PORT=6380')
             
             # Auto Agree License.
             popen('echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections')

--- a/honcho_manager.py
+++ b/honcho_manager.py
@@ -1,0 +1,25 @@
+import sys
+import os
+
+import click
+from honcho.manager import Manager
+
+REDIS_PORT = os.environ.get('CANDIS_REDIS_PORT') or 6379
+
+@click.command()
+@click.option('--env', default='dev', help='working environment')
+def run(env):
+    m = Manager()
+    if env == 'dev':
+        m.add_process('web', 'python -m candis')
+        m.add_process('node', 'npm start')
+        m.add_process('redis', 'redis-server --port {}'.format(REDIS_PORT))
+    else:
+        m.add_process('web', 'gunicorn candis.app:app')
+    m.loop()
+
+    sys.exit(m.returncode)
+
+if __name__ == '__main__':
+    run()
+

--- a/honcho_manager.py
+++ b/honcho_manager.py
@@ -1,10 +1,12 @@
 import sys
 import os
 
-import click
 from honcho.manager import Manager
+from envparse import env
+import click
 
-REDIS_PORT = os.environ.get('CANDIS_REDIS_PORT') or 6379
+env.read_envfile()
+REDIS_PORT = env.int('CANDIS_REDIS_PORT', default=6379)
 
 @click.command()
 @click.option('--env', default='dev', help='working environment')


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
~~Redis-server will start on REDIS_PORT set as environment variable. By default in get-candis script, it gets set to `6380`, which can be changed by user using `export REDIS_PORT=<any port>`.~~

Made a new python script `honcho_manager.py`, which works as a replacement for both `Procfile` and `Procfile.dev` by using *honcho Manager class*. The script will check if `CANDIS_REDIS_PORT` is set as an env. variable. If not it will switch to a fallback value, provided in the script - `6380`.

So instead of calling Procfile(.dev) through `make start` command, I have called up the script with arguements as `--env <'prod'/'dev'>` which is parsed by the argument parser. Used `click` to achieve the same.

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->

