### PR TITLE
Allow edit of more than 1 pipeline simultaneously

### DIFF
--- a/candis/app/client/app/reducer/DocumentProcessorReducer.jsx
+++ b/candis/app/client/app/reducer/DocumentProcessorReducer.jsx
@@ -178,7 +178,8 @@ const documentProcessor   = (state = initial, action) => {
       const node         = action.payload
       var   nodes        = state.nodes
 
-      if ( !state.nodes[node.code] )
+      // check if active pipeline already has the node same as action.payload.
+      if (!state.active.data.map(localNode => localNode.code).includes(node.code))
       {
         nodes            = cloneDeep(state.nodes)
         nodes[node.code] =

--- a/candis/app/client/app/tests/reducers/DocumentProcessorReducer.test.js
+++ b/candis/app/client/app/tests/reducers/DocumentProcessorReducer.test.js
@@ -88,16 +88,20 @@ test('should set active document provided as payload', () => {
     })
 })
 
-test('should set stage', () => {
-    const node = newDoc.data[0]
+test('should set stage for an active document', () => {
+    // taking a stage out of a document, changing its code and then putting in dokuments.active pipeline
+    const node = {
+        ...newDoc.data[0],
+        code: 'dummy'
+    }
     const state = documentProcessor(
-        undefined,
+        dokuments,
         {
             type: ActionType.DocumentProcessor.SET_STAGE,
             payload: node
     })
     expect(state).toEqual({
-        ...initial,
+        ...dokuments,
         nodes: expect.any(Object)
     })
     expect(state.nodes[node.code]).toEqual({


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
solves #103 
earlier if node is created in 1 pipeline with code say X (eg. dat.fle), then creating a new pipeline and making a same node with code X(eg. dat.fle) and then editing it creates an error because in `SET_STAGE` action (in documentProcessorReducer) we were checking the condition `if (! state.nodes[node.code])` which don't take into account that a new pipeline is being used. Instead, this PR uses: `if (!state.active.data.map(localNode => localNode.code).includes(node.code))` which ensures of making a new stage/node if and only if it doesn't exist in the active pipeline irrespective of the `state.nodes`.


###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None
