### PR TITLE
correct typo in JSX attribute

### DIFF
--- a/candis/app/client/app/component/widget/GistViewer.jsx
+++ b/candis/app/client/app/component/widget/GistViewer.jsx
@@ -9,7 +9,7 @@ class GistViewer extends React.Component
 
         return (
             <div className="panel-group" id="gist">
-                <div classsName="panel panel-default">
+                <div className="panel panel-default">
                     <div className="panel-heading">
                         <a href="javascript:void(0);" 
                             data-toggle="collapse" 


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - In GistViewer component, `classsName` is used instead of the correct `className`.


