### PR TITLE
Delete stage using unique node ID instead of code

### DIFF
--- a/candis/app/client/app/action/DocumentProcessorAction.jsx
+++ b/candis/app/client/app/action/DocumentProcessorAction.jsx
@@ -110,13 +110,13 @@ const stage =
 
     return dispatch
   },
-  delete: (code) => {
+  delete: (ID) => {
     const dispatch = (dispatch) => {
       const dokument = store.getState().documentProcessor.active
       
       var action = {
         payload: {
-          code: code,
+          ID: ID,
           data: dokument.data
         },
         type: ActionType.Pipeline.REMOVE_STAGE
@@ -125,7 +125,7 @@ const stage =
 
       if( dokument !== null ){
         var buffer = dokument.data.filter((node) => {
-          if( node.code == code ){
+          if( node.ID == ID ){
             return false
           }
           return true

--- a/candis/app/client/app/component/widget/PipelineEditor.jsx
+++ b/candis/app/client/app/component/widget/PipelineEditor.jsx
@@ -17,6 +17,7 @@ class PipelineEditor extends React.Component
 
 	onClick (e) {
 		const action = stage.delete(e.target.value)
+
 		this.props.dispatch(action)
 	}
 	
@@ -49,7 +50,7 @@ class PipelineEditor extends React.Component
 											</a>
 										</div>
 										<div className="col-xs-3" >
-											<button className="close" value={node.code} onClick={this.onClick}>&times;</button>
+											<button className="close" value={node.ID} onClick={this.onClick}>&times;</button>
 										</div>
 									</div>
 								</div>

--- a/candis/app/client/app/reducer/DocumentProcessorReducer.jsx
+++ b/candis/app/client/app/reducer/DocumentProcessorReducer.jsx
@@ -198,7 +198,7 @@ const documentProcessor   = (state = initial, action) => {
       
       const updatedNodes = [ ]
       payload.data.forEach((node) => {
-        if(node.code !== payload.code){
+        if(node.ID !== payload.ID){
           updatedNodes.push(node)
         }
       })

--- a/candis/app/client/app/tests/reducers/DocumentProcessorReducer.test.js
+++ b/candis/app/client/app/tests/reducers/DocumentProcessorReducer.test.js
@@ -218,7 +218,7 @@ test('should set stage for an active document', () => {
 })
 
 test('should remove node from state.documents and stata.active', () => {
-    const code = dokuments.active.data[0].code
+    const ID = dokuments.active.data[0].ID
     const data = dokuments.active.data
     const state = documentProcessor(
         dokuments,    
@@ -226,12 +226,12 @@ test('should remove node from state.documents and stata.active', () => {
             type: ActionType.Pipeline.REMOVE_STAGE,
             payload: {
                 data,
-                code
+                ID
             }
     })
     const reducedData = [ ]
     data.forEach((node) => {
-        if(node.code !== code){
+        if(node.ID !== ID){
             reducedData.push(node)
         }
     })


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
Instead of node/stage's `code`, use `ID` which is unique to delete the stage instead.
Earlier if we have multiple feature selection methods, deleting one would have deleted all the feature selection stages/nodes because they were having the same code.
