### PR TITLE
Check if pipeline already exists by its name instead of comparing the whole document's output.

### DIFF
--- a/candis/app/client/app/reducer/DocumentProcessorReducer.jsx
+++ b/candis/app/client/app/reducer/DocumentProcessorReducer.jsx
@@ -29,7 +29,7 @@ const documentProcessor   = (state = initial, action) => {
         const documents   = state.documents.slice().map((dokument) =>
         {
 
-          const exists    = isEqual(dokument.output, meta.output)
+          const exists    = isEqual(dokument.output.name, meta.output.name)
           if ( exists )
           {
             const pipe    = [ ]


### PR DESCRIPTION
… whole pipeline output data

<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
Since a pipeline name is unique and will be unique for a given user even after database integration, it's better to compare if names of the documents instead of the whole document's output value.
