### PR TITLE
dont call formik resetForm() after the component/form is unmounted

### DIFF
--- a/candis/app/client/app/component/form/Entrez.jsx
+++ b/candis/app/client/app/component/form/Entrez.jsx
@@ -189,7 +189,7 @@ class EntrezDataGrid extends React.Component {
           onRowSelect={this.onSelect}
           minHeight={500}
         />
-        <div className="row" style={marginTop=0.5}>
+        <div className="row">
           <div className="col-xs-8">
           </div>
           <div className="col-xs-4">        

--- a/candis/app/client/app/component/form/SignInForm.jsx
+++ b/candis/app/client/app/component/form/SignInForm.jsx
@@ -79,12 +79,12 @@ const SignInEnhanced = withFormik({
           username: values.username
         }
       }
+      setSubmitting(false)
       props.onSubmit(payload)
-      resetForm()
     }, ({response}) => {
+      setSubmitting(false)
       toastr.error(response.data.error.errors[0].message)
     })
-    setSubmitting(false)
   },
 })(SignInBasic)
 

--- a/candis/app/client/app/component/form/SignUpForm.jsx
+++ b/candis/app/client/app/component/form/SignUpForm.jsx
@@ -97,12 +97,12 @@ const SignUpEnhanced = withFormik({
           username: values.username
         }
       }
+      setSubmitting(false)
       props.onSubmit(payload)
-      resetForm()
     }, ({response}) => {
+      setSubmitting(false)
       toastr.error(response.data.error.errors[0].message)
     })
-    setSubmitting(false)
   },
 })(SignUpBasic)
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
Fixes #128 
after login form or signup form is submitted, it unmounts the SignUp and SignIn components, and thus we don't have access to the formik state, i.e. we cant call resetForm, or setSubmitting after it.
This PR fixes such behaviour.


