### PR TITLE
set axios default headers before setting up user state

### DIFF
--- a/candis/app/client/app/action/AppAction.jsx
+++ b/candis/app/client/app/action/AppAction.jsx
@@ -22,12 +22,12 @@ const signin = (payload) => {
   const dispatcher = (dispatch) => {
 	
 	storage.set('JWT_TOKEN', payload.token)	
-    storage.set('ACTIVE_USER', payload.user)
+	storage.set('ACTIVE_USER', payload.user)
+	
+	setAuthorizationToken(payload.token)
 	
 	const action = setUser(jwt.decode(payload.token))
 	dispatch(action)
-	
-	setAuthorizationToken(payload.token)
   }
   return dispatcher
 }


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
Solves #127 
Earlier with the change of state, getResource action was getting called even before axios.default.headers was set, this resulted a failed backend request because token was not even set, before a call to the backend. So this PR solves this, by first setting up the default headers, then only dispatch the setUser action.
