### PR TITLE
Add '-y' arg for installing yarn on a non interactive terminal - like docker build.

### DIFF
--- a/get-candis
+++ b/get-candis
@@ -220,7 +220,8 @@ def setup_candis(args = None):
             # Install yarn
             popen('curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -')
             popen('echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list')
-            popen('sudo apt-get update && sudo apt-get install yarn')
+            popen(aptget, 'update')
+            popen(aptget, 'install', '-y', 'yarn')
             
             # Auto Agree License.
             popen('echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections')


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation

###### Screenshots/GIFs:
<!-- Please include a screenshot/gif if your contribution modifies on-screen components -->
  - Screenshot

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - Steps

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None
