### PR TITLE
Add forgot_password endpoint

### DIFF
--- a/candis/app/server/models/user.py
+++ b/candis/app/server/models/user.py
@@ -27,6 +27,14 @@ class User(db.Model):
             db.session.rollback()
             db.session.flush()
             print(e)  # use logging
+        
+    def update_user(self, **kwargs):
+        for key, value in kwargs.items():
+            if key == 'password':
+                value = self._encrypt(value)
+            setattr(self, key, value)
+        db.session.add(self)
+        db.session.commit()
 
     @classmethod
     def get_user(cls, id_=None, username=None, email=None):

--- a/candis/app/server/utils/__init__.py
+++ b/candis/app/server/utils/__init__.py
@@ -1,2 +1,4 @@
 from candis.app.server.utils.tokens import login_required, logout_required
 from candis.app.server.utils.response import save_response_to_db
+from candis.app.server.utils.user import MailMessage
+

--- a/candis/app/server/utils/pipeline.py
+++ b/candis/app/server/utils/pipeline.py
@@ -20,4 +20,3 @@ def convert_to_stage_schema(dict_):
 
 def convert_to_pipeline_schema(**kwargs):
     pass
-

--- a/candis/app/server/utils/response.py
+++ b/candis/app/server/utils/response.py
@@ -18,18 +18,3 @@ def save_response_to_db(dict_):
         ))
     resp = ResponseModel(**dict_)
     resp.add_response()
-    
-    # print("Changing data or error!!!!---------------------------")
-    # last_added = ResponseModel.get_response(id=dict_['id'])
-    # print(json.loads(last_added.data))
-    # print(json.loads(last_added.error))
-    # error = json.loads(last_added.error)
-    # print("Type of error is: {}".format(type(error)))
-    # print("Last added id is: {}".format(last_added.id_))
-    # error = json.dumps(dict(modify='error class', key2='I am modified!'))
-    # last_added.error = error
-    # last_added.add_response()
-    # last_added = ResponseModel.get_response(id=dict_['id'])
-    # print("Last added id is: {}".format(last_added.id_))
-    # print("Last Added error-")
-    # print(json.loads(last_added.error))

--- a/candis/app/server/utils/user.py
+++ b/candis/app/server/utils/user.py
@@ -1,0 +1,7 @@
+class MailMessage():
+    
+    @classmethod
+    def forgot_password_body(cls, url, reset_token, time):
+        return '<h2>Reset token is: </h2><a href={}>{}</a><h3>Link is valid for {}.</h3>'.format(url, reset_token, time)
+
+


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
Completes 1st task of #140 - user enters email in `forgot_password` endpoint. If email is valid, JWT token with expiry time of 15 minutes, is sent to the email. With that reset_token and new_password, one can reset password on `reset_password` endpoint.

###### TODOs:<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - frontend part needs to be handled.
