### PR TITLE
Add ForgotPassword and ResetPassword forms for the frontend

### DIFF
--- a/candis/app/client/app/component/form/ForgotPasswordForm.jsx
+++ b/candis/app/client/app/component/form/ForgotPasswordForm.jsx
@@ -1,0 +1,34 @@
+import React from "react"
+import axios from 'axios'
+import PropTypes from "prop-types"
+import classNames from "classnames"
+import { connect } from 'react-redux'
+import { withFormik, Form, Field } from "formik"
+import * as Yup from "yup"
+
+import config from '../../config'
+
+const ForgotPasswordBasic = props => (
+  <Form className="form-inline">
+    <div className="form-group">
+      <label>Email</label>
+      <Field type="email" name="email" className="form-control" placeholder={props.email}/>
+      <small className="help-block">
+        {props.touched.email && props.errors.email}
+      </small>
+    </div>
+  </Form>
+)
+
+const ForgotPasswordEnhanced = withFormik({
+  mapPropsToValues: (props) => ({email: props.email || ""}),
+  validationSchema: Yup.object().shape({
+    email: Yup.string().email("Email is not valid").required("This field is required")
+  }),
+  onSubmit: (values) => {
+    console.log("Values are", values)
+  }
+})(ForgotPasswordBasic)
+
+export default ForgotPasswordEnhanced
+

--- a/candis/app/client/app/component/form/ResetPasswordForm.jsx
+++ b/candis/app/client/app/component/form/ResetPasswordForm.jsx
@@ -1,0 +1,56 @@
+import React from "react"
+import axios from 'axios'
+import PropTypes from "prop-types"
+import classNames from "classnames"
+import { connect } from 'react-redux'
+import { withFormik, Form, Field } from "formik"
+import * as Yup from "yup"
+
+import config from '../../config'
+
+const ResetPasswordBasic = props => (
+  <Form>
+    <div className="form-group">
+      <label>Password</label>
+      <Field type="password" name="password" className="form-control"/>
+      <small className="help-block">
+        {props.touched.password && props.errors.password}
+      </small>
+    </div>  
+
+    <div className="form-group">
+      <label>Confirm Password</label>
+      <Field type="password" name="confirmPassword" className="form-control"/>
+      <small className="help-block">
+        {props.touched.confirmPassword && props.errors.confirmPassword}
+      </small>
+    </div>
+    
+    <button className="btn btn-block btn-brand-primary">
+    <div className="text-center">
+      <div className="text-uppercase font-bold">
+        Reset Password
+      </div>
+    </div>
+    </button>
+  </Form>
+)
+
+const ResetPasswordEnhanced = withFormik({
+  mapPropsToValues: (props) => ({
+    password: props.password || "",
+    confirmPassword: props.confirmPassword || ""
+  }),
+
+  validationSchema: Yup.object().shape({
+    password: Yup.string().required("This field is required to login"),
+    confirmPassword: Yup.string().equalTo(Yup.ref('password'), 'passwords must match').required('Confirm password required')
+  }),
+
+  handleSubmit: (values) => {
+      console.log("values are ", values)
+  }
+})(ResetPasswordBasic)
+
+export default ResetPasswordEnhanced
+


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
WIP of 2nd task in #140 
added two formik forms - `ResetPasswordForm` and `ForgotPasswordForm`.

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - Connect frontend to backend api endpoints for reset_password functionality.
