### PR TITLE
Add python 3.7 version in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+dist: xenial
+sudo: true
 python:
   # - "2.6" # no longer supported.
   # - "2.7" # not supported.
@@ -8,6 +10,7 @@ python:
   - "3.5" 
   # - "3.5-dev"
   - "3.6"
+  - "3.7"
   # - "3.6-dev"
   # - "3.7-dev"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+# dist: xenial
 sudo: true
 python:
   # - "2.6" # no longer supported.


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
https://github.com/travis-ci/travis-ci/issues/9815
With python 3.7 released last month, checking if candis is compatible with the latest version. If not will be working on the same.