### PR TITLE
 Connected frontend feature of splitting the dataset to backend - Added Defaults setting Section in candis

### DIFF
--- a/candis/app/client/app/action/DefaultsAction.jsx
+++ b/candis/app/client/app/action/DefaultsAction.jsx
@@ -1,0 +1,21 @@
+import ActionType from '../constant/ActionType'
+
+const defaults = {
+  update: (updates) => {
+    const action = {
+      type: ActionType.Defaults.UPDATE,
+      payload: updates
+    }
+    
+    return action
+  },
+  restore: () => {
+    const action = {
+      type: ActionType.Defaults.RESTORE
+    }
+
+    return action
+  }
+}
+
+export default defaults

--- a/candis/app/client/app/action/PipelineAction.jsx
+++ b/candis/app/client/app/action/PipelineAction.jsx
@@ -11,7 +11,6 @@ const pipeline     =
 		const dispatch = (dispatch) =>
 		{
 			output = {...output, 'split_percent': store.getState().defaults.trainPercent}
-			console.log("output is ", output)
 			const action = pipeline.runRequest(output)
 			dispatch(action)
 

--- a/candis/app/client/app/action/PipelineAction.jsx
+++ b/candis/app/client/app/action/PipelineAction.jsx
@@ -1,8 +1,8 @@
 import axios      from 'axios'
 
 import config     from '../config'
-
 import ActionType from '../constant/ActionType'
+import store      from '../Store'
 
 const pipeline     =
 {
@@ -10,6 +10,8 @@ const pipeline     =
 	{
 		const dispatch = (dispatch) =>
 		{
+			output = {...output, 'split_percent': store.getState().defaults.trainPercent}
+			console.log("output is ", output)
 			const action = pipeline.runRequest(output)
 			dispatch(action)
 

--- a/candis/app/client/app/component/form/DefaultsForm.jsx
+++ b/candis/app/client/app/component/form/DefaultsForm.jsx
@@ -8,14 +8,35 @@ import { withFormik, Form, Field } from "formik"
 import * as Yup from "yup"
 
 import config from '../../config'
+import defaults from '../../action/DefaultsAction'
 
 const DefaultsBasic = props => {
   return(
     <div className="container-fluid">
       <Form>
-        <div className="slidecontainer">
-          <Field type="range" min="1" max="100" value="70" className="slider" name="trainPercent"/>
+
+        <div className="form-group">
+        <label className="control-label col-sm-4">Training data Percentage: </label>
+        <div className="col-sm-8">
+          <Field
+            type="number"
+            name={"trainPercent"}
+            className="form-control"
+            min="1"
+            max="100" 
+            value={props.values.trainPercent}
+          />
         </div>
+        </div>
+        
+        <div className="form-group">
+          <div className="col-sm-offset-4 col-sm-8">
+            <button type="submit" className="btn btn-block btn-primary">
+              <div className="text-uppercase font-bold">Update</div>
+            </button>
+          </div>
+        </div>
+
       </Form>
     </div>
   )
@@ -23,6 +44,20 @@ const DefaultsBasic = props => {
 
 const DefaultsEnhanced = withFormik({
   mapPropsToValues: (props) => ({
-    trainPercent: props.trainPercent || ""
-  })
+    trainPercent: props.trainPercent || props.defaults.trainPercent
+  }),
+  handleSubmit(values, { props }){
+    const action = defaults.update(values)
+    props.dispatch(action)
+    toastr.success("Defaults updated successfully!")
+  }
 })(DefaultsBasic)
+
+const mapStateToProps = (state, props) => {
+  const defaults = state.defaults
+  return {
+    defaults: defaults
+  }
+}
+
+export default connect(mapStateToProps)(DefaultsEnhanced)

--- a/candis/app/client/app/component/form/DefaultsForm.jsx
+++ b/candis/app/client/app/component/form/DefaultsForm.jsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { connect } from 'react-redux'
+import axios from 'axios'
+import PropTypes from "prop-types"
+import ReactDataGrid  from 'react-data-grid'
+import classNames from "classnames"
+import { withFormik, Form, Field } from "formik"
+import * as Yup from "yup"
+
+import config from '../../config'
+
+const DefaultsBasic = props => {
+  return(
+    <div className="container-fluid">
+      <Form>
+        <div className="slidecontainer">
+          <Field type="range" min="1" max="100" value="70" className="slider" name="trainPercent"/>
+        </div>
+      </Form>
+    </div>
+  )
+}
+
+const DefaultsEnhanced = withFormik({
+  mapPropsToValues: (props) => ({
+    trainPercent: props.trainPercent || ""
+  })
+})(DefaultsBasic)

--- a/candis/app/client/app/constant/ActionType.jsx
+++ b/candis/app/client/app/constant/ActionType.jsx
@@ -4,6 +4,12 @@ const ActionType =
   {
     RESET_STATE: 'ACTION_TYPE_ROOT_RESET_STATE'
   },
+
+  Defaults:
+  {
+    UPDATE: 'ACTION_TYPE_DEFAULTS_UPDATE',
+    RESTORE: 'ACTIONS_TYPE_DEFAULTS_RESTORE'
+  },
   
   App:
   {

--- a/candis/app/client/app/constant/Component.jsx
+++ b/candis/app/client/app/constant/Component.jsx
@@ -1,4 +1,5 @@
 import Entrez from '../component/form/Entrez'
+import DefaultsForm from '../component/form/DefaultsForm'
 import FileEditor   from '../component/widget/FileEditor'
 import FileViewer   from '../component/widget/FileViewer'
 import GistViewer   from '../component/widget/GistViewer'
@@ -8,6 +9,7 @@ import SelectViewer from '../component/widget/SelectViewer'
 const Component =
 {
   Entrez: Entrez,
+  DefaultsForm: Defaults,
     FileEditor: FileEditor,
     FileViewer: FileViewer,
     GistViewer: GistViewer,

--- a/candis/app/client/app/constant/Component.jsx
+++ b/candis/app/client/app/constant/Component.jsx
@@ -9,7 +9,7 @@ import SelectViewer from '../component/widget/SelectViewer'
 const Component =
 {
   Entrez: Entrez,
-  DefaultsForm: Defaults,
+  DefaultsForm: DefaultsForm,
     FileEditor: FileEditor,
     FileViewer: FileViewer,
     GistViewer: GistViewer,

--- a/candis/app/client/app/meta/Menus.jsx
+++ b/candis/app/client/app/meta/Menus.jsx
@@ -9,6 +9,7 @@ import { signout }  from '../action/AppAction'
 import { read, write, getResource } from '../action/AsynchronousAction'
 import { getFiles } from '../util'
 import modal        from '../action/ModalAction'
+import defaults     from '../action/DefaultsAction'
 import Component    from '../constant/Component'
 
 const Menus = [
@@ -113,17 +114,20 @@ const Menus = [
             icon: `${config.routes.icons}/settings.png`,
          tooltip: 'Open Settings View',
          onClick: (dispatch) => {
-           toastr.warning('To be implemented.')
            const dialog = {
              component: Component.DefaultsForm,
              title: 'Default Settings',
              size: 'lg',
              buttons: [
                {
-                 label: "Reset To Defaults",
+                 label: "Restore Defaults",
                  className: "btn-primary",
                  onClick: () => {
-                   toastr.warning('To be implemented')
+                   let action = defaults.restore()
+                   dispatch(action)
+                   toastr.success("Defaults restored successfully!")
+                   action = modal.hide()
+                   dispatch(action)
                  }
                },
                {

--- a/candis/app/client/app/meta/Menus.jsx
+++ b/candis/app/client/app/meta/Menus.jsx
@@ -8,6 +8,8 @@ import FileFormat   from '../constant/FileFormat'
 import { signout }  from '../action/AppAction'
 import { read, write, getResource } from '../action/AsynchronousAction'
 import { getFiles } from '../util'
+import modal        from '../action/ModalAction'
+import Component    from '../constant/Component'
 
 const Menus = [
   {
@@ -112,6 +114,34 @@ const Menus = [
          tooltip: 'Open Settings View',
          onClick: (dispatch) => {
            toastr.warning('To be implemented.')
+           const dialog = {
+             component: Component.DefaultsForm,
+             title: 'Default Settings',
+             size: 'lg',
+             buttons: [
+               {
+                 label: "Reset To Defaults",
+                 className: "btn-primary",
+                 onClick: () => {
+                   toastr.warning('To be implemented')
+                 }
+               },
+               {
+                 label: "Ok",
+                 className: "btn-primary",
+                 onClick: () => {
+                   const action = modal.hide()
+                   dispatch(action)
+                 }
+               }
+             ],
+             props:
+             {
+               classNames: { root: ['no-background', 'no-border', 'no-shadow', 'no-margin'] }
+             }
+           }
+           const action = modal.show(dialog)
+           dispatch(action)
          }
       }
     ]

--- a/candis/app/client/app/reducer/DefaultsReducer.jsx
+++ b/candis/app/client/app/reducer/DefaultsReducer.jsx
@@ -1,0 +1,27 @@
+import shortid    from 'shortid'
+import isEqual    from 'lodash.isequal'
+import cloneDeep  from 'lodash.clonedeep'
+
+import ActionType from '../constant/ActionType'
+import FileFormat from '../constant/FileFormat'
+import nodesMeta from '../meta/nodes'
+
+const initial = {
+  trainPercent : 70
+}
+
+const Defaults = (state = initial, action) => {
+  switch(action.type){
+    case ActionType.Defaults.UPDATE: {
+      const updates = action.payload
+      return {...state, ...updates}
+    }
+    
+    case ActionType.Defaults.RESTORE: {
+      return initial
+    }
+  }
+  return state
+}
+
+export default Defaults

--- a/candis/app/client/app/reducer/index.jsx
+++ b/candis/app/client/app/reducer/index.jsx
@@ -6,11 +6,11 @@ import documentProcessor from './DocumentProcessorReducer'
 import modal             from './ModalReducer'
 import dataEditor        from './DataEditorReducer'
 import data              from './DataReducer'
-import entrez			 from './EntrezReducer'
-import ActionType 		 from '../constant/ActionType'
+import entrez			       from './EntrezReducer'
+import ActionType 		   from '../constant/ActionType'
 
 const Reducer = combineReducers({ app, modal, documentProcessor,
-	toolBox, dataEditor, data, entrez })
+	toolBox, dataEditor, data, entrez})
 
 const rootReducer = (state, action) => {
 	if (action.type === ActionType.Root.RESET_STATE) {

--- a/candis/app/client/app/reducer/index.jsx
+++ b/candis/app/client/app/reducer/index.jsx
@@ -7,10 +7,11 @@ import modal             from './ModalReducer'
 import dataEditor        from './DataEditorReducer'
 import data              from './DataReducer'
 import entrez			       from './EntrezReducer'
+import defaults					 from './DefaultsReducer'
 import ActionType 		   from '../constant/ActionType'
 
 const Reducer = combineReducers({ app, modal, documentProcessor,
-	toolBox, dataEditor, data, entrez})
+	toolBox, dataEditor, data, entrez, defaults })
 
 const rootReducer = (state, action) => {
 	if (action.type === ActionType.Root.RESET_STATE) {

--- a/candis/app/client/app/tests/actions/PipelineAction.test.js
+++ b/candis/app/client/app/tests/actions/PipelineAction.test.js
@@ -57,9 +57,10 @@ const mock = new MockAdapter(axios)
 
  test('should setup pipeline.run action object', (done) => {
     const data = { data: true }  // dummy data which is returned by successful axios call.
+    dokuments.active = {...dokuments.active, 'split_percent': 70}
     mock.onPost(config.routes.API.pipeline.run, dokuments.active).reply(200, data)
     const store = createMockStore({})
-
+    
     store.dispatch(pipeline.run(dokuments.active)).then(() => {
 
         const actions = store.getActions()

--- a/candis/app/server/api/pipeline.py
+++ b/candis/app/server/api/pipeline.py
@@ -26,10 +26,11 @@ from candis.app.server.models import PipelineRun, Pipeline as PipelineModel, Cda
 # HINT: Can be written better?
 @app.route(CONFIG.App.Routes.API.Pipeline.RUN, methods = ['POST'])
 @login_required
-def run(delay = 5, split_percent = 30):
+def run(delay = 5):
     response         = Response()
 
     parameters       = addict.Dict(request.get_json())
+    split_percent = parameters.split_percent or 70
 
     decoded_token = jwt.decode(request.headers.get('token'), app.config['SECRET_KEY'])
     username = decoded_token['username']

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,7 +2813,7 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formik@0.11.11:
+formik@^0.11.11:
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/formik/-/formik-0.11.11.tgz#4b02838133c0196b1ef443aa973766cd097ec4a5"
   dependencies:
@@ -4804,6 +4804,10 @@ mixin-object@^2.0.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.22.1:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -5830,10 +5834,6 @@ property-expr@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.3.2.tgz#2df60082c243e79118924ecb8f7ae7183b4fc43e"
 
-proptypes@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proptypes/-/proptypes-1.1.0.tgz#78b3828a5aa6bb1308939e0de3c6044dfd4bd239"
-
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -6099,6 +6099,10 @@ react-select@^1.2.1:
     classnames "^2.2.4"
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
+
+react-slider@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/react-slider/-/react-slider-0.11.2.tgz#ae014e1454c3cdd5f28b5c2495b2a08abd9971e6"
 
 react-sortable-hoc@^0.6.8:
   version "0.6.8"


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
Completes 1 part of frontend of issue #145 
So now user dont have to set every time the split ratio for train:test data. Instead added this in default settings section, which can be updated for the user.
![screenshot from 2018-07-24 18-58-22](https://user-images.githubusercontent.com/20624380/43142555-5137b054-8f76-11e8-91e5-99af62609465.png)


###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - Last part of #145 
