### PR TITLE
Remove procfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,8 @@ console:
 
 start:
 ifeq ($(ENV), development)
-	# $(HONCHO) start --procfile $(BASEDIR)/Procfile.dev
 	$(PYTHON) $(BASEDIR)/$(HONCHO_MANAGER) --env 'dev'
 else
-	# $(HONCHO) start
 	$(PYTHON) $(BASEDIR)/$(HONCHO_MANAGER) --env 'prod'
 endif
 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn candis.app:app

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,0 @@
-web: python -m candis
-node: npm start


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Explanation
Since we have honcho_manager.py, we can start candis using Makefile:
`make start` will start candis in a specfic environment(prod or dev), depending upon the ENV environment variable.
Or directly:
`python3 honcho_manager.py --end <prod|dev>`