### PR TITLE
Fix default name parameter bug in entrez API

### DIFF
--- a/candis/data/entrez/api.py
+++ b/candis/data/entrez/api.py
@@ -51,7 +51,7 @@ class API(object):
         if validate_email(email):
             self.email = email
 
-        if not isinstance(name, str):
+        if name and not isinstance(name, str):
             raise TypeError('name should be a string')
         
         if api_key and not isinstance(api_key, str):


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Now name need not to be given in entrez API as written in the docs.

