### PR TITLE
Expose port 8888 in Dockerfile to use jupyter notebooks from inside the docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /app
 ENV PYTHONPATH="/app/candis"
 
 # Expose port 5000
-EXPOSE 5000
+EXPOSE 5000 8888
 
 # Launch Candis
 CMD ["python3", "-m", "candis"]

--- a/README.md
+++ b/README.md
@@ -124,16 +124,10 @@ $ candis --cdata path/to/data.cdata --config path/to/config.json
 ```
 
 **Using the Jupyter Notebook from inside the docker container**
-* Entering the candis_app container
+* Starting the jupyter notebook server inside the candis app container
 
 ```
-$ docker exec -it candis_app_1 bash
-```
-
-* Starting the jupyter notebook server inside the docker container
-
-```
-$ jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
+$ docker-compose exec app jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
 ```
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ via Python
 $ candis --cdata path/to/data.cdata --config path/to/config.json
 ```
 
+**Using the Jupyter Notebook from inside the docker container**
+* Entering the candis_app container
+
+```
+$ docker exec -it candis_app_1 bash
+```
+
+* Starting the jupyter notebook server inside the docker container
+
+```
+$ jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
+```
+
 ### Features
 * Converting a CDATA to an **ARFF** file
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
     depends_on:
       - db
     volumes:
-      - .:/app      
+      - .:/app
+    ports:
+      - "8888:8888"      
   cache:
     <<: *defaults
     image: redis


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand your contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Now by using one simple command one can use the jupyter notebooks from inside the docker container without needing to install the dependencies on local.

###### Screenshots/GIFs:
<!-- Please include a screenshot/gif if your contribution modifies on-screen components -->
  - 
![image](https://user-images.githubusercontent.com/32803738/58486964-77f93e00-8184-11e9-99fa-f5d2b5ff85c7.png)


###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - `docker exec -it candis_app_1 bash`
  - `jupyter notebook --ip 0.0.0.0 --no-browser --allow-root`
